### PR TITLE
token is attached to report URL

### DIFF
--- a/lib/LocalServer.js
+++ b/lib/LocalServer.js
@@ -236,7 +236,7 @@ function _getOpenReportCommand() {
 	};
 	return (openURLIn[process.platform] || (url => `xdg-open "${url}"`))(_getReportURL());
 }
-function _getReportURL() { return `${userConfig.url}/report/` }
+function _getReportURL() { return `${userConfig.url}/report/` + (userConfig.token ? `?token=${userConfig.token}` : ``) }
 function _getTestURL() { return `${userConfig.url}/ajax/test` }
 function _getWelcomeURL() { return `${userConfig.url}/` }
 function _getKillURL() { return `${userConfig.url}/ajax/kill` }


### PR DESCRIPTION
For the sake of fixing issue #31 and out of own interest, I implemented that the token is attached to the report URL when executing the 'codingTracker.showReport' command. 
The token is only attached when it is set. 